### PR TITLE
Add:NameカラムにNotNull制約、文字数制限、ユニークインデックスを追加

### DIFF
--- a/db/migrate/20230421020937_change_tasks_name_not_null.rb
+++ b/db/migrate/20230421020937_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :name, false 
+  end
+end

--- a/db/migrate/20230421021823_change_tasks_name_limit30.rb
+++ b/db/migrate/20230421021823_change_tasks_name_limit30.rb
@@ -1,0 +1,8 @@
+class ChangeTasksNameLimit30 < ActiveRecord::Migration[5.2]
+  def up
+    change_column :tasks, :name, :string, limit: 30
+  end
+  def down
+    change_column :tasks, :name, :string
+  end
+end

--- a/db/migrate/20230421022014_add_name_index_to_tasks.rb
+++ b/db/migrate/20230421022014_add_name_index_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddNameIndexToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_20_133215) do
+ActiveRecord::Schema.define(version: 2023_04_21_022014) do
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", limit: 30, null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tasks_on_name", unique: true
   end
 
 end


### PR DESCRIPTION
### やったこと
Taskモデルのnameカラムのデータ内容制限を追加

- NOTNULL制約
- 文字数３０字まで
- ユニークインデックス