### PR TITLE
Add scope to tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'rails_autolink'
 gem 'bootstrap', '~> 4.6'
 gem 'slim-rails', '3.1.3'
 gem 'html2slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
+    rails_autolink (1.1.8)
+      actionview (> 3.1)
+      activesupport (> 3.1)
+      railties (> 3.1)
     railties (5.2.8.1)
       actionpack (= 5.2.8.1)
       activesupport (= 5.2.8.1)
@@ -249,6 +253,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)
   rails (~> 5.2.6)
+  rails_autolink
   sass-rails (~> 5.0)
   selenium-webdriver
   slim-rails (= 3.1.3)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,11 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+
   def index
-    @tasks = current_user.tasks
+    @tasks = current_user.tasks.recent
   end
 
   def show
-    @task = current_user.tasks.find(params[:id])
   end
 
   def new
@@ -12,13 +13,11 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = current_user.tasks.find(params[:id])
   end
 
   def update
-    task = current_user.tasks.find(params[:id])
-    task.update!(task_params)
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました。"
+    @task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を更新しました。"
   end
 
   def create
@@ -32,14 +31,17 @@ class TasksController < ApplicationController
   end
 
   def destroy
-    task = current_user.tasks.find(params[:id])
-    task.destroy
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+    @task.destroy
+    redirect_to tasks_url, notice: "タスク「#{@task.name}」を削除しました。"
   end
 
   private
 
   def task_params
     params.require(:task).permit(:name, :description)
+  end
+
+  def set_task
+    @task = current_user.tasks.find(params[:id])
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
 
   belongs_to :user
 
+  scope :recent, -> { order(created_at: :desc) }
+
   private
 
   def validate_name_not_including_commma

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -12,7 +12,7 @@ table.table.table-hover
       td = @task.name     
     tr
       th = Task.human_attribute_name(:description)
-      td = simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div")
+      td = auto_link(simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div"))
     tr
       th = Task.human_attribute_name(:created_at)
       td = @task.created_at

--- a/db/migrate/20230425013253_remove_index_to_name.rb
+++ b/db/migrate/20230425013253_remove_index_to_name.rb
@@ -1,0 +1,10 @@
+class RemoveIndexToName < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :tasks, :name
+  end
+
+  def down
+    remove_index :tasks, :name
+    add_index :tasks, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_21_084248) do
+ActiveRecord::Schema.define(version: 2023_04_25_013253) do
 
   create_table "tasks", force: :cascade do |t|
     t.string "name", limit: 30, null: false
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 2023_04_21_084248) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
-    t.index ["name"], name: "index_tasks_on_name", unique: true
     t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 


### PR DESCRIPTION
### やったこと
`task_controller`内の`@task = current_user.tasks.find(params[:id])`をメソッド化し、共通部分にbefore_actionとして設定
scopeを用いて、クエリをモデルにまとめた

### 修正点
taskモデルのnameカラムのuniqueインデックスが適用されていたため、開発上の利便性のため削除した